### PR TITLE
Make the application name of the desktop file better suited for menus

### DIFF
--- a/com.github.Eloston.UngoogledChromium.desktop
+++ b/com.github.Eloston.UngoogledChromium.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Version=1.0
-Name=ungoogled-chromium
+Name=Ungoogled Chromium
 # Only KDE 4 seems to use GenericName, so we reuse the KDE strings.
 # From Ubuntu's language-pack-kde-XX-base packages, version 9.04-20090413.
 GenericName=Web Browser


### PR DESCRIPTION
instead of more terminal-friendly name the desktop file currently uses.