### PR TITLE
Add f-e-d-c support

### DIFF
--- a/com.github.Eloston.UngoogledChromium.metainfo.xml
+++ b/com.github.Eloston.UngoogledChromium.metainfo.xml
@@ -29,6 +29,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="88.0.4324.146" date="2021-02-03"/>
     <release version="88.0.4324.104" date="2021-01-30"/>
     <release version="87.0.4280.141" date="2021-01-07"/>
     <release version="87.0.4280.88"  date="2020-12-04"/>

--- a/com.github.Eloston.UngoogledChromium.yaml
+++ b/com.github.Eloston.UngoogledChromium.yaml
@@ -174,6 +174,10 @@ modules:
       - type: git
         url: https://github.com/Eloston/ungoogled-chromium
         tag: 88.0.4324.104-1
+        x-checker-data:
+          type: anitya
+          project-id: 147740
+          tag-template: $version
 
   - name: chromium
     buildsystem: simple
@@ -247,6 +251,10 @@ modules:
       - type: archive
         url: https://commondatastorage.googleapis.com/chromium-browser-official/chromium-88.0.4324.104.tar.xz
         sha256: 7dbdda0df8955811ada33a9505cad2f2e17f007827c435b591ba571c5dcd0147
+        x-checker-data:
+          type: anitya
+          project-id: 13344
+          url-template: https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$version.tar.xz
       - type: patch
         paths:
           - patches/0001-ffmpeg-Use-royalty-free-libfdk-aac-for-AAC-playback.patch

--- a/com.github.Eloston.UngoogledChromium.yaml
+++ b/com.github.Eloston.UngoogledChromium.yaml
@@ -173,7 +173,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/Eloston/ungoogled-chromium
-        tag: 88.0.4324.104-1
+        tag: 88.0.4324.146-1
         x-checker-data:
           type: anitya
           project-id: 147740
@@ -249,8 +249,8 @@ modules:
       - rm -rf /app/ugc
     sources:
       - type: archive
-        url: https://commondatastorage.googleapis.com/chromium-browser-official/chromium-88.0.4324.104.tar.xz
-        sha256: 7dbdda0df8955811ada33a9505cad2f2e17f007827c435b591ba571c5dcd0147
+        url: https://commondatastorage.googleapis.com/chromium-browser-official/chromium-88.0.4324.146.tar.xz
+        sha256: 38b118fbe8bbdf89e4f170ced090088f5eb2bb68f2295abbb0006cc94b7f827d
         x-checker-data:
           type: anitya
           project-id: 13344


### PR DESCRIPTION
This MR adds support to [flatpak-external-data-checker (f-e-d-c)](https://github.com/flathub/flatpak-external-data-checker) for the source code of Chromium and ungoogled-chomium, and also bumps ungoogled-chromium to the latest build.

Here's how it looks like when running it:

```bash
$ sh run-in-container.sh ~/Projects/com.github.Eloston.UngoogledChromium/com.github.Eloston.UngoogledChromium.yaml
[...]
+ 2021-02-03 15:26:24,581    INFO src.checker: [1/9] checking cups-2.3.3-source.tar.gz
+ 2021-02-03 15:26:25,419    INFO src.checker: [2/9] checking gtk.git
+ 2021-02-03 15:26:25,420    INFO src.checker: [3/9] checking Python-2.7.18.tar.xz
+ 2021-02-03 15:26:26,122    INFO src.checker: [4/9] checking xcb-proto-1.14.tar.xz
+ 2021-02-03 15:26:26,674    INFO src.checker: [5/9] checking krb5-1.18.2.tar.gz
+ 2021-02-03 15:26:27,485    INFO src.checker: [6/9] checking flextop
+ 2021-02-03 15:26:27,485    INFO src.checker: [7/9] checking pipewire.git
+ 2021-02-03 15:26:27,485    INFO src.checker: [8/9] checking ungoogled-chromium
+ 2021-02-03 15:26:28,168    INFO src.checker: [9/9] checking chromium-88.0.4324.104.tar.xz
CHANGE SOON: ungoogled-chromium
 Has a new version:
  URL:     https://github.com/Eloston/ungoogled-chromium
  Commit:  d8e821c16212647250ea6d848537e92b1b739f82
  Tag:     88.0.4324.146-1
  Branch:  None
  Version: 88.0.4324.146-1


CHANGE SOON: chromium-88.0.4324.104.tar.xz
 Has a new version:
  URL:     https://commondatastorage.googleapis.com/chromium-browser-official/chromium-88.0.4324.146.tar.xz
  SHA256:  38b118fbe8bbdf89e4f170ced090088f5eb2bb68f2295abbb0006cc94b7f827d
  Size:    857222644
  Version: 88.0.4324.146
```