### PR TITLE
Update to Ungoogled Chromium 98.0.4758.102

### DIFF
--- a/build-aux/install.sh
+++ b/build-aux/install.sh
@@ -3,8 +3,9 @@
 mkdir -p /app/chromium
 
 pushd out/Release
-# Keep file names in sync with build_devel_flatpak.py
-for path in chrome chrome_crashpad_handler icudtl.dat *.so *.pak *.bin *.png locales MEIPreload swiftshader; do
+for path in chrome chrome_crashpad_handler icudtl.dat *.so libvulkan.so.1 *.pak *.bin *.png locales MEIPreload swiftshader vk_swiftshader_icd.json; do
+	# All the 'libVk*' names are just for debugging, stuff like "libVkICD_mock_icd" and "libVkLayer_khronos_validation".
+	[[ "$path" == libVk* ]] && continue
 	cp -rv $path /app/chromium || true
 done
 popd

--- a/com.github.Eloston.UngoogledChromium.metainfo.xml
+++ b/com.github.Eloston.UngoogledChromium.metainfo.xml
@@ -29,6 +29,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="98.0.4758.102" date="2022-02-16"/>
     <release version="98.0.4758.80" date="2022-02-03"/>
     <release version="97.0.4692.99" date="2022-01-20"/>
     <release version="97.0.4692.71" date="2022-01-06"/>

--- a/com.github.Eloston.UngoogledChromium.yaml
+++ b/com.github.Eloston.UngoogledChromium.yaml
@@ -194,8 +194,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/Eloston/ungoogled-chromium
-        tag: 98.0.4758.80-1
-        commit: 61d47f6bcdec8c71151144f07c7f8a0197eeca7a
+        tag: 98.0.4758.102-1
+        commit: 4508f48c5dc90c84386db8826e1a3e06c77df5d2
 
   - name: chromium
     buildsystem: simple
@@ -218,8 +218,8 @@ modules:
       - rm -rf /app/ugc
     sources:
       - type: archive
-        url: https://commondatastorage.googleapis.com/chromium-browser-official/chromium-98.0.4758.80.tar.xz
-        sha256: c87266e20f860a32c48affc70a769368d1b876dbad768e3aa93ee3c335944171
+        url: https://commondatastorage.googleapis.com/chromium-browser-official/chromium-98.0.4758.102.tar.xz
+        sha256: 415b47e912766cd07f9f52e95bc6470b835acf1d6f566ae32e66ba8be608f33e
       - type: archive
         url: https://commondatastorage.googleapis.com/chromium-browser-clang/Linux_x64/clang-llvmorg-14-init-11564-g37fbf238-3.tgz
         sha256: e79cb8f1e65b44b932b9fd98365b3771e913e7275d9e92e59eca4334c5689a28


### PR DESCRIPTION
Per the Chrome Releases Blog [1], this update contains fixes for:

- CVE-2022-0603: Use after free in File Manager. Reported by Chaoyuan Peng (@ret2happy) on 2022-01-22
- CVE-2022-0604: Heap buffer overflow in Tab Groups. Reported by Krace on 2021-11-24
- CVE-2022-0605: Use after free in Webstore API. Reported by Thomas Orlita  on 2022-01-13
- CVE-2022-0606: Use after free in ANGLE. Reported by Cassidy Kim of Amber Security Lab, OPPO Mobile Telecommunications Corp. Ltd. on 2022-01-17
- CVE-2022-0607: Use after free in GPU. Reported by 0x74960 on 2021-09-17
- CVE-2022-0608: Integer overflow in Mojo. Reported by Sergei Glazunov of Google Project Zero on 2021-11-16
- CVE-2022-0609: Use after free in Animation. Reported by Adam Weidemann and Clément Lecigne of Google's Threat Analysis Group on 2022-02-10
- CVE-2022-0610: Inappropriate implementation in Gamepad API. Reported by Anonymous on 2022-01-08

[1]: https://chromereleases.googleblog.com/2022/02/stable-channel-update-for-desktop_14.html