### PR TITLE
Update repository urls to use ungoogled-software organisation

### DIFF
--- a/com.github.Eloston.UngoogledChromium.metainfo.xml
+++ b/com.github.Eloston.UngoogledChromium.metainfo.xml
@@ -8,7 +8,7 @@
   <summary>A lightweight approach to removing Google web service dependency</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>BSD-3-Clause and LGPL-2.1+ and Apache-2.0 and IJG and MIT and GPL-2.0+ and ISC and OpenSSL and (MPL-1.1 or GPL-2.0 or LGPL-2.0)</project_license>
-  <url type="homepage">https://github.com/Eloston/ungoogled-chromium</url>
+  <url type="homepage">https://github.com/ungoogled-software/ungoogled-chromium</url>
   <description>
    <p>
     ungoogled-chromium is Google Chromium, sans dependency on Google web services.

--- a/com.github.Eloston.UngoogledChromium.yaml
+++ b/com.github.Eloston.UngoogledChromium.yaml
@@ -134,7 +134,7 @@ modules:
       - cp -r $PWD /app/ugc
     sources:
       - type: git
-        url: https://github.com/Eloston/ungoogled-chromium
+        url: https://github.com/ungoogled-software/ungoogled-chromium
         tag: 103.0.5060.114-2
         commit: 441693013e31600fc39f36296dd205a386b1b89f
 


### PR DESCRIPTION
The ungoogled-chromium repository has recently moved from the Eloston user to the ungoogled-software organisation.