### PR TITLE
Enable HEVC support unconditionally

### DIFF
--- a/build-aux/apply-gentoo-patches.sh
+++ b/build-aux/apply-gentoo-patches.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -ex
+
+# Enable HEVC unconditionally (irrespective of whether platform has certain hardware acceleration or not)
+# https://github.com/PF4Public/gentoo-overlay/blob/b19cb1445792956848aab89f7b94ffcaad4ab0bf/www-client/ungoogled-chromium/ungoogled-chromium-113.0.5672.63_p1.ebuild#L393-L396
+sed -i '/^bool IsHevcProfileSupported(const VideoType& type) {$/{s++bool IsHevcProfileSupported(const VideoType\& type) { return true;+;h};${x;/./{x;q0};x;q1}' \
+			media/base/supported_types.cc

--- a/com.github.Eloston.UngoogledChromium.yaml
+++ b/com.github.Eloston.UngoogledChromium.yaml
@@ -140,6 +140,7 @@ modules:
         CXXFLAGS: -Wno-unknown-warning-option -Wno-unknown-pragmas
     build-commands:
       - ./apply-arch-patches.sh
+      - ./apply-gentoo-patches.sh
       - /app/ugc/utils/prune_binaries.py ./ /app/ugc/pruning.list
       - /app/ugc/utils/patches.py apply ./ /app/ugc/patches
       - /app/ugc/utils/domain_substitution.py apply -r /app/ugc/domain_regex.list


### PR DESCRIPTION
* By default Chromium checks whether the platform has certain and "guaranteed" support for hardware decoding wrt to HEVC.
* This seems like a not so subtle attempt to drive users to AV1.
* Thank you to @PF4Public for the sed command and guidance on how this feature gets enabled on Chromium.
* Closes #105