### PR TITLE
add `--socket=pcsc` to make fido keys work

### DIFF
--- a/com.github.Eloston.UngoogledChromium.yaml
+++ b/com.github.Eloston.UngoogledChromium.yaml
@@ -19,6 +19,7 @@ finish-args:
   - --socket=pulseaudio
   - --socket=x11
   - --socket=wayland
+  - --socket=pcsc
   - --system-talk-name=org.freedesktop.Avahi
   - --system-talk-name=org.freedesktop.UPower
   - --talk-name=com.canonical.AppMenu.Registrar

--- a/com.github.Eloston.UngoogledChromium.yaml
+++ b/com.github.Eloston.UngoogledChromium.yaml
@@ -16,10 +16,10 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=cups
+  - --socket=pcsc # FIDO2
   - --socket=pulseaudio
   - --socket=x11
   - --socket=wayland
-  - --socket=pcsc
   - --system-talk-name=org.freedesktop.Avahi
   - --system-talk-name=org.freedesktop.UPower
   - --talk-name=com.canonical.AppMenu.Registrar


### PR DESCRIPTION
See https://github.com/ungoogled-software/ungoogled-chromium/issues/2341