### PR TITLE
Disable ARM64 builds for now

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "only-arches": ["aarch64", "x86_64"]
+  "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
Currently they are failing and I don't know why. Disable them until
I figure out how to fix it. I don't have any ARM64 device I could test
these builds with anyway, so it is not a priority for me.

Signed-off-by: rany <rany2@riseup.net>