### PR TITLE
Fix AAC audio failing to play due to FFmpegAllowLists

### DIFF
--- a/patches/chromium/_sources.json
+++ b/patches/chromium/_sources.json
@@ -17,7 +17,8 @@
       "patches/chromium/Clang-build-script-Disable-hwasan.patch",
       "patches/chromium/clang-build-script-Support-disabling-the-bundled-libxml2.patch",
       "patches/chromium/Clang-build-script-Don-t-build-against-the-sysroot.patch",
-      "patches/chromium/Clang-build-script-add-support-for-building-a-subset-of-ta.patch"
+      "patches/chromium/Clang-build-script-add-support-for-building-a-subset-of-ta.patch",
+      "patches/chromium/media-Add-libfdk_aac-to-the-audio-codec-allow-list.patch"
     ]
   }
 ]

--- a/patches/chromium/media-Add-libfdk_aac-to-the-audio-codec-allow-list.patch
+++ b/patches/chromium/media-Add-libfdk_aac-to-the-audio-codec-allow-list.patch
@@ -1,0 +1,25 @@
+From 1cf2263a98ff27ac0448f22c1861b89e800cf50e Mon Sep 17 00:00:00 2001
+From: Ryan Gonzalez <git@refi64.dev>
+Date: Wed, 13 Dec 2023 14:13:55 -0600
+Subject: [PATCH] media: Add libfdk_aac to the audio codec allow list
+
+---
+ media/filters/ffmpeg_glue.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/media/filters/ffmpeg_glue.cc b/media/filters/ffmpeg_glue.cc
+index af52aeb5173af..58e4703684de1 100644
+--- a/media/filters/ffmpeg_glue.cc
++++ b/media/filters/ffmpeg_glue.cc
+@@ -145,7 +145,7 @@ const char* FFmpegGlue::GetAllowedAudioDecoders() {
+         "vorbis,libopus,flac,pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,"
+         "mp3,pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw");
+ #if BUILDFLAG(USE_PROPRIETARY_CODECS)
+-    allowed_decoders += ",aac";
++    allowed_decoders += ",libfdk_aac";
+ #endif
+     return allowed_decoders;
+   }());
+-- 
+2.41.0
+


### PR DESCRIPTION
Chromium has the "aac" codec in the allow list, but we use libfdk-aac instead, which has a different codec name.

Fixes https://github.com/flathub/org.chromium.Chromium/issues/340