### PR TITLE
Move to 23.08 runtime bump sdk extensions and drop leftover stuff

### DIFF
--- a/build-aux/bootstrap.sh
+++ b/build-aux/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # Needed to build GN itself.
-. /usr/lib/sdk/llvm14/enable.sh
+. /usr/lib/sdk/llvm17/enable.sh
 
 # GN will use these variables to configure its own build, but they introduce
 # compat issues w/ Clang and aren't used by Chromium itself anyway, so just
@@ -17,8 +17,8 @@ if [[ -d third_party/llvm-build/Release+Asserts/bin ]]; then
 else
 	python3 tools/clang/scripts/build.py --disable-asserts \
 		--skip-checkout --use-system-cmake --use-system-libxml \
-		--host-cc=/usr/lib/sdk/llvm14/bin/clang \
-		--host-cxx=/usr/lib/sdk/llvm14/bin/clang++ \
+		--host-cc=/usr/lib/sdk/llvm17/bin/clang \
+		--host-cxx=/usr/lib/sdk/llvm17/bin/clang++ \
 		--target-triple=$(clang -dumpmachine) \
 		--without-android --without-fuchsia --without-zstd \
 		--with-ml-inliner-model=

--- a/build-aux/build.sh
+++ b/build-aux/build.sh
@@ -8,8 +8,8 @@ ln_overwrite_all() {
 # Link our verisons of Node and OpenJDK into Chromium so the build scripts will
 # use them. For OpenJDK especially, this is a workaround for:
 # https://bugs.chromium.org/p/chromium/issues/detail?id=1192875
-ln_overwrite_all /usr/lib/sdk/node16 third_party/node/linux/node-linux-x64
-ln_overwrite_all /usr/lib/sdk/openjdk11 third_party/jdk/current
+ln_overwrite_all /usr/lib/sdk/node18 third_party/node/linux/node-linux-x64
+ln_overwrite_all /usr/lib/sdk/openjdk21 third_party/jdk/current
 
 ninja -C out/ReleaseFree -j"${FLATPAK_BUILDER_N_JOBS}" libffmpeg.so
 ninja -C out/Release -j"${FLATPAK_BUILDER_N_JOBS}" chrome chrome_crashpad_handler

--- a/com.github.Eloston.UngoogledChromium.yaml
+++ b/com.github.Eloston.UngoogledChromium.yaml
@@ -1,16 +1,15 @@
 app-id: com.github.Eloston.UngoogledChromium
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.chromium.Chromium.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 command: chromium
 finish-args:
   - --require-version=1.8.2
   - --filesystem=home
   - --filesystem=/run/.heim_org.h5l.kcm-socket
   - --device=all
-  - --env=GTK_PATH=/app/lib/gtkmodules
   - --env=LD_LIBRARY_PATH=/app/chromium/nonfree-codecs/lib
   - --share=ipc
   - --share=network
@@ -64,9 +63,9 @@ add-extensions:
     autodelete: true
 
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.llvm14
-  - org.freedesktop.Sdk.Extension.node16
-  - org.freedesktop.Sdk.Extension.openjdk11
+  - org.freedesktop.Sdk.Extension.llvm17
+  - org.freedesktop.Sdk.Extension.node18
+  - org.freedesktop.Sdk.Extension.openjdk21
 
 modules:
   - name: readelf-symlink


### PR DESCRIPTION
* Switch to 23.08 runtime and bump Sdk extensions

* Bump llvm ext version in build script

* Bump openjdk and nodejs ext in build script

* Drop python2 module

Chromium supports python3 for a while

* Drop GTK_PATH variable

It's no longer necessary

* Delete gtk-settings.ini

No longer used

* Delete libsecret.json

No longer used - moved to Baseapp

* Delete gtk3-werror.patch

No longer used