### PR TITLE
Whitelist plasma-6 keyring qbus for storing passwords

### DIFF
--- a/com.github.Eloston.UngoogledChromium.yaml
+++ b/com.github.Eloston.UngoogledChromium.yaml
@@ -27,6 +27,7 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.kde.kwalletd5
+  - --talk-name=org.kde.kwalletd6
   - --talk-name=org.gnome.SessionManager
   - --own-name=org.mpris.MediaPlayer2.chromium.*
   - --persist=.pki # https://github.com/flathub/com.github.Eloston.UngoogledChromium/issues/34


### PR DESCRIPTION
Recently distro's have been upgrading all users to plasma-6. In order for passwords stored in the keyring to stay/become accessible the new "org.kde.kwalletd6" needs to be added to the whitelist.