### PR TITLE
yml: Set VK Driver and Layers Env variables

### DIFF
--- a/com.github.Eloston.UngoogledChromium.yaml
+++ b/com.github.Eloston.UngoogledChromium.yaml
@@ -11,6 +11,8 @@ finish-args:
   - --filesystem=/run/.heim_org.h5l.kcm-socket
   - --device=all
   - --env=LD_LIBRARY_PATH=/app/chromium/nonfree-codecs/lib
+  - --env=VK_ADD_LAYER_PATH=/usr/lib/x86_64-linux-gnu/GL/vulkan
+  - --env=VK_ADD_DRIVER_FILES=/usr/lib/x86_64-linux-gnu/GL/vulkan/icd.d
   - --share=ipc
   - --share=network
   - --socket=cups


### PR DESCRIPTION
VK_ADD_LAYER_PATH defines where is path who contains the vk layers. VK_ADD_DRIVER_FILES defines where can find vulkan drivers icd.d files.

This can be use in future for others flathub chromium's based packages